### PR TITLE
use stdlib ed25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ from SUPERCOP, *not* the current implementation in NaCL. The difference is that
 the entire 64-byte signature is prepended to the message; in the current version
 of NaCL, separate bits are prepended and appended to the message.
 
-- Compared with `golang.org/x/crypto/ed25519`, this library's Sign
+- Compared with `crypto/ed25519`, this library's Sign
 implementation returns the message along with the signature, and Verify
 expects the first 64 bytes of the message to be the signature. This simplifies
 the API and matches the behavior of the ref10 implementation and other NaCL

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -16,7 +16,7 @@ import (
 	"io"
 	"strconv"
 
-	"golang.org/x/crypto/ed25519"
+	"crypto/ed25519"
 )
 
 const (


### PR DESCRIPTION
benefit: one less external dependency / entry in go.mod!
downside: doesnt support [go <1.13](https://golang.org/doc/go1.13#crypto/ed25519), but technically <1.14 is no longer supported according to [go's release policy](https://golang.org/doc/devel/release.html#policy) and this project [only tests 1.15+ in ci](https://github.com/kevinburke/nacl/blob/master/.github/workflows/ci.yml#L7)