### PR TITLE
cmd: added box (encrypt or decrypt) cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ go get github.com/kevinburke/nacl
 
 Or you can Git clone the code directly to $GOPATH/src/github.com/kevinburke/nacl.
 
+#### Using `cmd`s
+
+When used as scripts in modules (for e.g. automation) the shipped `cmd`s can
+be called e.g. like this:
+
+```
+go run $(go list -m -f '{{.Dir}}' github.com/kevinburke/nacl)/cmd/nacl-generate-box-key/main.go
+```
+
 ### Who am I?
 
 While you probably shouldn't trust random security code from the Internet,

--- a/cmd/nacl-box/main.go
+++ b/cmd/nacl-box/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+
+	"github.com/kevinburke/nacl"
+	"github.com/kevinburke/nacl/box"
+)
+
+var w = os.Stdout
+
+func main() {
+
+	encrypt := flag.Bool("encrypt", false, "Encrypt (instead of decrypt)")
+	pubhex := flag.String("pubhex", "", "Public key in hex format")
+	privhex := flag.String("privhex", "", "Private key in hex format")
+	flag.Parse()
+	pub, err := nacl.Load(*pubhex)
+	if err != nil {
+		panic(err)
+	}
+	prv, err := nacl.Load(*privhex)
+	if err != nil {
+		panic(err)
+	}
+	buf, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	if *encrypt {
+		w.Write(box.EasySeal(buf, pub, prv))
+	} else {
+		out, err := box.EasyOpen(buf, pub, prv)
+		if err != nil {
+			panic(err)
+		}
+		w.Write((out))
+	}
+
+}


### PR DESCRIPTION
As it says: adds encrypt / decrypt cmd and references how to use cmd's in general from the POV of modules (as helper scripts).